### PR TITLE
Fix stale csclient compare reference and enforce cp.py consistency

### DIFF
--- a/.github/workflows/csclient_compare.sh
+++ b/.github/workflows/csclient_compare.sh
@@ -1,13 +1,20 @@
 #!/bin/bash
-#Every app should have the same version of csclient.py. This test verifies a new app or modified app does not have an out of date csclient.py.
-file2="app_template/csclient.py"
-for folder in ./*/;
-do
-        if test -f $folder/csclient.py; then
-                file1=$folder/csclient.py
-                if !(cmp "$file1" "$file2"); then
-                        echo "The csclient.py file in "$folder" is not the correct version"
-                        exit 1
-                fi
-        fi
+# Every app should have the same version of cp.py. This test verifies a new
+# app or modified app does not have an out-of-date copy.
+
+reference_file="./cp.py"
+
+if [[ ! -f "$reference_file" ]]; then
+  echo "Missing reference file: $reference_file"
+  exit 1
+fi
+
+for folder in ./*/; do
+  app_file="${folder%/}/cp.py"
+  if [[ -f "$app_file" ]]; then
+    if ! cmp -s "$app_file" "$reference_file"; then
+      echo "The cp.py file in ${folder%/} is not the correct version"
+      exit 1
+    fi
+  fi
 done

--- a/.github/workflows/update-cp-py-and-build.yml
+++ b/.github/workflows/update-cp-py-and-build.yml
@@ -107,6 +107,9 @@ jobs:
         
         # Clean up the temporary script
         rm -f update_cp_py.py
+
+        chmod +x ./.github/workflows/csclient_compare.sh
+        ./.github/workflows/csclient_compare.sh
         
         if [ $UPDATED -eq 1 ]; then
           echo "Files were updated, proceeding with commit"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace stale `csclient.py` comparison logic in `.github/workflows/csclient_compare.sh` with `cp.py` consistency checks
- add explicit missing-reference handling so a missing `./cp.py` fails with a clear error message instead of a raw `cmp` missing-file error
- wire the compare script into the active CI workflow (`update-cp-py-and-build.yml`) immediately after `cp.py` synchronization so the script is no longer dead code

## Problem Verified
- `.github/workflows/csclient_compare.sh` referenced `app_template/csclient.py`, which does not exist
- if any app had `csclient.py`, `cmp` would fail with a missing-file error rather than a clean comparison outcome
- no active workflow invoked `csclient_compare.sh`

## Validation
- `bash -n ./.github/workflows/csclient_compare.sh`
- ran script from `/tmp` to verify explicit missing reference handling:
  - output: `Missing reference file: ./cp.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80fdf3d4-a2b5-4fbc-82c2-3665f549ebae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80fdf3d4-a2b5-4fbc-82c2-3665f549ebae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

